### PR TITLE
fix(branch): update branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,6 @@ slack_sdk==3.31.*
 slack-bolt==1.19.*
 scrapy==2.11.*
 mc-providers==2.0.*
-numpy==1.23.* # freeze this here for tensorflow compatibility
+numpy==1.26.* # freeze this here for tensorflow compatibility
 requests
 requests_ratelimiter==0.7.*


### PR DESCRIPTION
Fix model loading error for PJ project by upgrading to an appropriate NumPy version.  numpy._core used in PJ model cannot be imported with current NumPy version which is preventing PJ stories from being classified correctly.