### PR TITLE
refactor(mc-providers): remove use of mc-providers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,9 @@ mediacloud-metadata>=1.0.0
 slack_sdk==3.35.*
 slack-bolt==1.23.*
 scrapy==2.12.*
-mc-providers==3.1.*
 numpy==1.26.* # freeze this here for tensorflow compatibility
 requests
 requests_ratelimiter==0.7.*
 redis==6.0.*
+wayback-news-search==1.2.*
 kombu

--- a/scripts/queue_mediacloud_stories.py
+++ b/scripts/queue_mediacloud_stories.py
@@ -15,7 +15,6 @@ import processor
 
 processor.disable_package_loggers()
 
-import mc_providers
 
 import processor.database as database
 import processor.database.projects_db as projects_db
@@ -36,10 +35,6 @@ INCLUSIVE_RANGE_START = "{"
 EXCLUSIVE_RANGE_END = "]"
 
 logger = logging.getLogger(__name__)
-
-MC_PLATFORM_NAME = mc_providers.provider_name(
-    mc_providers.PLATFORM_ONLINE_NEWS, mc_providers.PLATFORM_SOURCE_MEDIA_CLOUD
-)
 
 
 def load_projects_task() -> List[Dict]:
@@ -87,7 +82,6 @@ def _process_project_task(args: Dict) -> Dict:
             pub_start_date,
             pub_end_date,
             collection_ids=project["media_collections"],
-            platform=MC_PLATFORM_NAME,
         )["relevant"]
     except Exception as e:
         logger.error(
@@ -118,7 +112,6 @@ def _process_project_task(args: Dict) -> Dict:
                 pagination_token=page_token,
                 page_size=STORIES_PER_PAGE,
                 sort_order="desc",
-                platform=MC_PLATFORM_NAME,
                 expanded=True,
             )
             logger.info(


### PR DESCRIPTION
remove` MC_PLATFORM_NAME` from queue_mediacloud_stories.py 
and `OnlineNewsWayBackMachineProvider` from queue_wayback_stories.py.

Since `all_items` and `all_articles` return slightly different results for the wayback fetcher, we should proceed with caution. For example, using `wayback-news-search`, the articles do not have a unique id.